### PR TITLE
Fixed typo around wildcard character

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Once the MariaDB container is deployed, you can enter the following commands int
 from shell: mysql -u root -p
 CREATE DATABASE bookstackapp;
 GRANT USAGE ON *.* TO 'myuser'@'%' IDENTIFIED BY 'mypassword';
-GRANT ALL privileges ON `bookstackapp`.* TO 'myuser'@%;
+GRANT ALL privileges ON `bookstackapp`.* TO 'myuser'@'%';
 FLUSH PRIVILEGES;
 ```
 


### PR DESCRIPTION
Without the single quotation marks, this command would result in the following error:

```
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '%' at line 1
```

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

