### PR TITLE
Fixed APP_URL documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker create \
   -e DB_USER=<yourdbuser> \
   -e DB_PASS=<yourdbpass> \
   -e DB_DATABASE=bookstackapp \
-  -e APPURL=your.site.here.xyz \
+  -e APP_URL=https://your.site.here.xyz \
   -p 6875:80 \
   -v <path to data>:/config \
   --restart unless-stopped \
@@ -89,7 +89,7 @@ services:
       - DB_USER=<yourdbuser>
       - DB_PASS=<yourdbpass>
       - DB_DATABASE=bookstackapp
-      - APPURL=your.site.here.xyz
+      - APP_URL=https://your.site.here.xyz
     volumes:
       - <path to data>:/config
     ports:
@@ -111,7 +111,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e DB_USER=<yourdbuser>` | for specifying the database user |
 | `-e DB_PASS=<yourdbpass>` | for specifying the database password |
 | `-e DB_DATABASE=bookstackapp` | for specifying the database to be used |
-| `-e APPURL=your.site.here.xyz` | for specifying the url your application will be accessed on  |
+| `-e APP_URL=https://your.site.here.xyz` | for specifying the url your application will be accessed on  |
 | `-v /config` | this will store any uploaded data on the docker host |
 
 ## User / Group Identifiers
@@ -150,14 +150,14 @@ Then docker start bookstackapp to start the container. You should then be able t
 
 Default username is admin@admin.com with password of **password**
 
-If you intend to use this application behind a reverse proxy, such as our LetsEncrypt container or Traefik you will need to make sure that the `APPURL` environment variable is set, or it will not work
+If you intend to use this application behind a reverse proxy, such as our LetsEncrypt container or Traefik you will need to make sure that the `APP_URL` environment variable is set, or it will not work
 
 Documentation can be found at https://www.bookstackapp.com/docs/
 
 ### Advanced Users
 If you wish to use the extra functionality of BookStack such as email, memcache, ldap and so on you will need to make your own .env file with guidance from the BookStack documentation.
 
-When you create the container, do not set any arguements for SQL or APPURL. The container will copy an .env file to /config/www/.env on your host system for you to edit. 
+When you create the container, do not set any arguements for SQL or APP_URL. The container will copy an .env file to /config/www/.env on your host system for you to edit. 
 
 ### Composer
 


### PR DESCRIPTION
"APPURL" was incorrect as an environmental variable. Also, added https:// to display how the variable works for reverse proxy setups. Was getting CSS errors because it would try to request http by default.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

