### PR TITLE
fix SQL command syntax in Application Setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Once the MariaDB container is deployed, you can enter the following commands int
 from shell: mysql -u root -p
 CREATE DATABASE bookstackapp;
 GRANT USAGE ON *.* TO 'myuser'@'%' IDENTIFIED BY 'mypassword';
-GRANT ALL privileges ON `bookstackapp`.* TO 'myuser'@%;
+GRANT ALL privileges ON `bookstackapp`.* TO 'myuser'@'%';
 FLUSH PRIVILEGES;
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

This fixes a SQL syntax error experienced when using the LinuxServer MariaDB container.
[Here is an example](https://i.imgur.com/rez6DtD.png) that shows both the error and that it is fixed by the introduction of ' around %) (I am using `hass` in place of `myuser` because I'm using it for Home Assistant -- but that's irrelevant).

