### PR TITLE
Add WKHTMLTOPDF for use in .env file if desired

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,15 @@ RUN \
 	php7-simplexml \
 	php7-tidy \
 	php7-tokenizer && \
+ echo "**** install wkhtmltopdf ****" && \
+ apk add --no-cache \
+	ttf-freefont \
+	fontconfig && \
+ apk add --no-cache \
+	--repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+	--allow-untrusted \
+	qt5-qtbase-dev \
+	wkhtmltopdf && \
  echo "**** configure php-fpm ****" && \
  sed -i 's/;clear_env = no/clear_env = no/g' /etc/php7/php-fpm.d/www.conf && \
  echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM lsiobase/nginx:3.9
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG BOOKSTACK_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="homerr"
 
@@ -10,10 +11,10 @@ LABEL maintainer="homerr"
 ARG BOOKSTACK_RELEASE
 
 RUN \
- echo "**** install build packages ****" && \
+ echo "**** install packages ****" && \
  apk add --no-cache  \
 	curl \
-	tar \
+	fontconfig \
 	memcached \
 	netcat-openbsd \
 	php7-ctype \
@@ -29,15 +30,10 @@ RUN \
 	php7-phar \
 	php7-simplexml \
 	php7-tidy \
-	php7-tokenizer && \
- echo "**** install wkhtmltopdf ****" && \
- apk add --no-cache \
+	php7-tokenizer \
+	qt5-qtbase \
+	tar \
 	ttf-freefont \
-	fontconfig && \
- apk add --no-cache \
-	--repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
-	--allow-untrusted \
-	qt5-qtbase-dev \
 	wkhtmltopdf && \
  echo "**** configure php-fpm ****" && \
  sed -i 's/;clear_env = no/clear_env = no/g' /etc/php7/php-fpm.d/www.conf && \
@@ -46,7 +42,7 @@ RUN \
  mkdir -p\
 	/var/www/html && \
  if [ -z ${BOOKSTACK_RELEASE+x} ]; then \
- BOOKSTACK_RELEASE=$(curl -sX GET "https://api.github.com/repos/bookstackapp/bookstack/releases/latest" \
+	BOOKSTACK_RELEASE=$(curl -sX GET "https://api.github.com/repos/bookstackapp/bookstack/releases/latest" \
 	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
  fi && \
  curl -o \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -30,6 +30,15 @@ RUN \
 	php7-simplexml \
 	php7-tidy \
 	php7-tokenizer && \
+ echo "**** install wkhtmltopdf ****" && \
+ apk add --no-cache \
+	ttf-freefont \
+	fontconfig && \
+ apk add --no-cache \
+	--repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+	--allow-untrusted \
+	qt5-qtbase-dev \
+	wkhtmltopdf && \
  echo "**** configure php-fpm ****" && \
  sed -i 's/;clear_env = no/clear_env = no/g' /etc/php7/php-fpm.d/www.conf && \
  echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -3,6 +3,7 @@ FROM lsiobase/nginx:arm64v8-3.9
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG BOOKSTACK_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="homerr"
 
@@ -10,10 +11,10 @@ LABEL maintainer="homerr"
 ARG BOOKSTACK_RELEASE
 
 RUN \
- echo "**** install build packages ****" && \
+ echo "**** install packages ****" && \
  apk add --no-cache  \
 	curl \
-	tar \
+	fontconfig \
 	memcached \
 	netcat-openbsd \
 	php7-ctype \
@@ -29,15 +30,10 @@ RUN \
 	php7-phar \
 	php7-simplexml \
 	php7-tidy \
-	php7-tokenizer && \
- echo "**** install wkhtmltopdf ****" && \
- apk add --no-cache \
+	php7-tokenizer \
+	qt5-qtbase \
+	tar \
 	ttf-freefont \
-	fontconfig && \
- apk add --no-cache \
-	--repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
-	--allow-untrusted \
-	qt5-qtbase-dev \
 	wkhtmltopdf && \
  echo "**** configure php-fpm ****" && \
  sed -i 's/;clear_env = no/clear_env = no/g' /etc/php7/php-fpm.d/www.conf && \
@@ -46,7 +42,7 @@ RUN \
  mkdir -p\
 	/var/www/html && \
  if [ -z ${BOOKSTACK_RELEASE+x} ]; then \
- BOOKSTACK_RELEASE=$(curl -sX GET "https://api.github.com/repos/bookstackapp/bookstack/releases/latest" \
+	BOOKSTACK_RELEASE=$(curl -sX GET "https://api.github.com/repos/bookstackapp/bookstack/releases/latest" \
 	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
  fi && \
  curl -o \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -3,6 +3,7 @@ FROM lsiobase/nginx:arm32v7-3.9
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG BOOKSTACK_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="homerr"
 
@@ -10,10 +11,10 @@ LABEL maintainer="homerr"
 ARG BOOKSTACK_RELEASE
 
 RUN \
- echo "**** install build packages ****" && \
+ echo "**** install packages ****" && \
  apk add --no-cache  \
 	curl \
-	tar \
+	fontconfig \
 	memcached \
 	netcat-openbsd \
 	php7-ctype \
@@ -29,15 +30,10 @@ RUN \
 	php7-phar \
 	php7-simplexml \
 	php7-tidy \
-	php7-tokenizer && \
- echo "**** install wkhtmltopdf ****" && \
- apk add --no-cache \
+	php7-tokenizer \
+	qt5-qtbase \
+	tar \
 	ttf-freefont \
-	fontconfig && \
- apk add --no-cache \
-	--repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
-	--allow-untrusted \
-	qt5-qtbase-dev \
 	wkhtmltopdf && \
  echo "**** configure php-fpm ****" && \
  sed -i 's/;clear_env = no/clear_env = no/g' /etc/php7/php-fpm.d/www.conf && \
@@ -46,7 +42,7 @@ RUN \
  mkdir -p\
 	/var/www/html && \
  if [ -z ${BOOKSTACK_RELEASE+x} ]; then \
- BOOKSTACK_RELEASE=$(curl -sX GET "https://api.github.com/repos/bookstackapp/bookstack/releases/latest" \
+	BOOKSTACK_RELEASE=$(curl -sX GET "https://api.github.com/repos/bookstackapp/bookstack/releases/latest" \
 	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
  fi && \
  curl -o \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -30,6 +30,15 @@ RUN \
 	php7-simplexml \
 	php7-tidy \
 	php7-tokenizer && \
+ echo "**** install wkhtmltopdf ****" && \
+ apk add --no-cache \
+	ttf-freefont \
+	fontconfig && \
+ apk add --no-cache \
+	--repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+	--allow-untrusted \
+	qt5-qtbase-dev \
+	wkhtmltopdf && \
  echo "**** configure php-fpm ****" && \
  sed -i 's/;clear_env = no/clear_env = no/g' /etc/php7/php-fpm.d/www.conf && \
  echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \

--- a/README.md
+++ b/README.md
@@ -144,18 +144,23 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 &nbsp;
 ## Application Setup
 
-Default username is admin@admin.com with password of **password**, access the container at http://dockerhost:6875.
+The default username is admin@admin.com with the password of **password**, access the container at http://dockerhost:6875.
 
-This application is dependent on an MySQL database be it one you already have or a new one. If you do not already have one, set up our MariaDB container here https://hub.docker.com/r/linuxserver/mariadb/.
+This application is dependent on a MySQL database be it one you already have or a new one. If you do not already have one, set up our MariaDB container here https://hub.docker.com/r/linuxserver/mariadb/.
 
 If you intend to use this application behind a subfolder reverse proxy, such as our LetsEncrypt container or Traefik you will need to make sure that the `APP_URL` environment variable is set, or it will not work
 
 Documentation for BookStack can be found at https://www.bookstackapp.com/docs/
 
 ### Advanced Users (full control over the .env file)
-If you wish to use the extra functionality of BookStack such as email, memcache, ldap and so on you will need to make your own .env file with guidance from the BookStack documentation.
+If you wish to use the extra functionality of BookStack such as email, Memcache, LDAP and so on you will need to make your own .env file with guidance from the BookStack documentation.
 
-When you create the container, do not set any arguments for any SQL settings, or APP_URL. The container will copy an .env file to /config/www/.env on your host system for you to edit.
+When you create the container, do not set any arguments for any SQL settings, or APP_URL. The container will copy an exemplary .env file to /config/www/.env on your host system for you to edit.
+
+#### PDF Rendering
+[wkhtmltopdf](https://wkhtmltopdf.org/) is available to use as an alternative PDF rendering generator as described at https://www.bookstackapp.com/docs/admin/pdf-rendering/.
+
+The path to wkhtmltopdf in this image to include in your .env file is `/usr/bin/wkhtmltopdf`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -144,18 +144,21 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 &nbsp;
 ## Application Setup
 
+
 The default username is admin@admin.com with the password of **password**, access the container at http://dockerhost:6875.
 
 This application is dependent on a MySQL database be it one you already have or a new one. If you do not already have one, set up our MariaDB container here https://hub.docker.com/r/linuxserver/mariadb/.
+
 
 If you intend to use this application behind a subfolder reverse proxy, such as our LetsEncrypt container or Traefik you will need to make sure that the `APP_URL` environment variable is set, or it will not work
 
 Documentation for BookStack can be found at https://www.bookstackapp.com/docs/
 
 ### Advanced Users (full control over the .env file)
-If you wish to use the extra functionality of BookStack such as email, Memcache, LDAP and so on you will need to make your own .env file with guidance from the BookStack documentation.
+If you wish to use the extra functionality of BookStack such as email, memcache, ldap and so on you will need to make your own .env file with guidance from the BookStack documentation.	If you wish to use the extra functionality of BookStack such as email, Memcache, LDAP and so on you will need to make your own .env file with guidance from the BookStack documentation.
 
-When you create the container, do not set any arguments for any SQL settings, or APP_URL. The container will copy an exemplary .env file to /config/www/.env on your host system for you to edit.
+
+When you create the container, do not set any arguments for any SQL settings, or APP_URL. The container will copy an .env file to /config/www/.env on your host system for you to edit.	When you create the container, do not set any arguments for any SQL settings, or APP_URL. The container will copy an exemplary .env file to /config/www/.env on your host system for you to edit.
 
 #### PDF Rendering
 [wkhtmltopdf](https://wkhtmltopdf.org/) is available to use as an alternative PDF rendering generator as described at https://www.bookstackapp.com/docs/admin/pdf-rendering/.
@@ -187,15 +190,6 @@ Below are the instructions for updating containers:
 * Start the new container: `docker start bookstack`
 * You can also remove the old dangling images: `docker image prune`
 
-### Via Taisun auto-updater (especially useful if you don't remember the original parameters)
-* Pull the latest image at its tag and replace it with the same env variables in one shot:
-  ```
-  docker run --rm \
-  -v /var/run/docker.sock:/var/run/docker.sock taisun/updater \
-  --oneshot bookstack
-  ```
-* You can also remove the old dangling images: `docker image prune`
-
 ### Via Docker Compose
 * Update all images: `docker-compose pull`
   * or update a single image: `docker-compose pull bookstack`
@@ -203,8 +197,38 @@ Below are the instructions for updating containers:
   * or update a single container: `docker-compose up -d bookstack`
 * You can also remove the old dangling images: `docker image prune`
 
+### Via Watchtower auto-updater (especially useful if you don't remember the original parameters)
+* Pull the latest image at its tag and replace it with the same env variables in one run:
+  ```
+  docker run --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  containrrr/watchtower \
+  --run-once bookstack
+  ```
+* You can also remove the old dangling images: `docker image prune`
+
+## Building locally
+
+If you want to make local modifications to these images for development purposes or just to customize the logic: 
+```
+git clone https://github.com/linuxserver/docker-bookstack.git
+cd docker-bookstack
+docker build \
+  --no-cache \
+  --pull \
+  -t linuxserver/bookstack:latest .
+```
+
+The ARM variants can be built on x86_64 hardware using `multiarch/qemu-user-static`
+```
+docker run --rm --privileged multiarch/qemu-user-static:register --reset
+```
+
+Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64`.
+
 ## Versions
 
+* **14.06.19:** - Add wkhtmltopdf to image for PDF rendering.
 * **20.04.19:** - Rebase to Alpine 3.9, add MySQL init logic.
 * **22.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **20.01.19:** - Added php7-curl

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -77,21 +77,31 @@ custom_compose: |
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
-  Default username is admin@admin.com with password of **password**, access the container at http://dockerhost:6875.
 
-  This application is dependent on an MySQL database be it one you already have or a new one. If you do not already have one, set up our MariaDB container here https://hub.docker.com/r/linuxserver/mariadb/.
+  The default username is admin@admin.com with the password of **password**, access the container at http://dockerhost:6875.
 
+  This application is dependent on a MySQL database be it one you already have or a new one. If you do not already have one, set up our MariaDB container here https://hub.docker.com/r/linuxserver/mariadb/.
+
+  
   If you intend to use this application behind a subfolder reverse proxy, such as our LetsEncrypt container or Traefik you will need to make sure that the `APP_URL` environment variable is set, or it will not work
 
   Documentation for BookStack can be found at https://www.bookstackapp.com/docs/
 
   ### Advanced Users (full control over the .env file)
-  If you wish to use the extra functionality of BookStack such as email, memcache, ldap and so on you will need to make your own .env file with guidance from the BookStack documentation.
+  If you wish to use the extra functionality of BookStack such as email, memcache, ldap and so on you will need to make your own .env file with guidance from the BookStack documentation.	If you wish to use the extra functionality of BookStack such as email, Memcache, LDAP and so on you will need to make your own .env file with guidance from the BookStack documentation.
+  
+  
+  When you create the container, do not set any arguments for any SQL settings, or APP_URL. The container will copy an .env file to /config/www/.env on your host system for you to edit.	When you create the container, do not set any arguments for any SQL settings, or APP_URL. The container will copy an exemplary .env file to /config/www/.env on your host system for you to edit.
+  
+  #### PDF Rendering
+  [wkhtmltopdf](https://wkhtmltopdf.org/) is available to use as an alternative PDF rendering generator as described at https://www.bookstackapp.com/docs/admin/pdf-rendering/.
+  
+  The path to wkhtmltopdf in this image to include in your .env file is `/usr/bin/wkhtmltopdf`.
 
-  When you create the container, do not set any arguments for any SQL settings, or APP_URL. The container will copy an .env file to /config/www/.env on your host system for you to edit.
 
 # changelog
 changelogs:
+  - { date: "14.06.19:", desc: "Add wkhtmltopdf to image for PDF rendering." }
   - { date: "20.04.19:", desc: "Rebase to Alpine 3.9, add MySQL init logic." }
   - { date: "22.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "20.01.19:", desc: "Added php7-curl"}


### PR DESCRIPTION
BookStack has built-in support for `wkhtmltopdf`, but it must be installed on the system or be added to the application directory. 

This PR adds the dependencies and `wkhtmltopdf` itself from the alpine test repo.

Users of the image can then modify their instance's `.env` file to use wkhtmltopdf instead as described in the [BookStack documentation](https://www.bookstackapp.com/docs/admin/pdf-rendering/)

IE: `WKHTMLTOPDF=/usr/bin/wkhtmltopdf`