### PR TITLE
skip mysql endpoint check if DB_HOST is empty

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -57,9 +57,11 @@ fi
 
 # check for the mysql endpoint for 30 seconds
 END=$((SECONDS+30))
-while [ ${SECONDS} -lt ${END} ]; do
+while [ ${SECONDS} -lt ${END} ] && [ "${DB_HOST}" ];
+	do
 	/usr/bin/nc -z ${DB_HOST} 3306 && \
-	if [ ! -z "$(/usr/bin/nc -w1 ${DB_HOST} 3306)" ]; then
+	if [ ! -z "$(/usr/bin/nc -w1 ${DB_HOST} 3306)" ];
+		then
 		[ ! -z "${RUN}" ] && break
 		RUN="RAN"
 		# we sleep here again due to first run init on DB containers


### PR DESCRIPTION
also formatted "do" and "then" in this section for style consistency

closes #31 
