### PR TITLE
fix substitution of APP_URL when provided

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -58,7 +58,7 @@ if [ "${DB_USER}" ];
 fi
 
 # set appurl if detected
-[[ "${APP_URL}" ]] && sed -i "s,#\sAPP_URL.*,APP_URL=${APP_URL},g" /config/www/.env
+[ -n "${APP_URL}" ] && sed -r "s,([#\s]*)?APP_URL=.*,APP_URL=${APP_URL},g" -i /config/www/.env
 
 # check for the mysql endpoint for 30 seconds
 END=$((SECONDS+30))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:

Looking at the following line, I can see why `APP_URL` is not being applied in `/config/www/.env`

```shell
# set appurl if detected
[[ "${APP_URL}" ]] && sed -i "s,#\sAPP_URL.*,APP_URL=${APP_URL},g" /config/www/.env
```

This substitution is expecting `# APP_URL` but the example env file doesn't include a space: `#APP_URL`.

The workaround is to manually edit your `/config/www/.env` file and avoid providing environment variables that would cause it to be overwritten.

## Benefits of this PR and context:

Fixes one of the symptoms described in https://github.com/linuxserver/docker-bookstack/issues/58

## How Has This Been Tested?

I tested the new sed string from the command line, before copying the patched `50-config` into the existing [v0.29.3-ls99](https://hub.docker.com/layers/linuxserver/bookstack/v0.29.3-ls99/images/sha256-1816b21f6cab056ffba41733781b43f6ee31f4e81ceadfb4a0efbbc3a89497fa?context=explore) image.

https://github.com/klutchell/balena-bookstack/commit/703a0ebe36ece339ebaf90f452099ad4ac2ff442


## Source / References:

https://github.com/linuxserver/docker-bookstack/issues/58
https://github.com/klutchell/balena-bookstack/commit/703a0ebe36ece339ebaf90f452099ad4ac2ff442
