### PR TITLE
Resolving php-local.ini mangling

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -61,8 +61,8 @@ fi
 [ -n "${APP_URL}" ] && sed -r "s,([#\s]*)?APP_URL=.*,APP_URL=${APP_URL},g" -i /config/www/.env
 
 ## Bump php upload max filesize and post max size to 100MB by default
-grep -qx 'upload_max_filesize' /config/php/php-local.ini || echo 'upload_max_filesize = 100M' >> /config/php/php-local.ini
-grep -qx 'post_max_size' /config/php/php-local.ini || echo 'post_max_size = 100M' >> /config/php/php-local.ini
+grep -qx '^upload_max_filesize.*$' /config/php/php-local.ini || echo 'upload_max_filesize = 100M' >> /config/php/php-local.ini
+grep -qx '^post_max_size.*$' /config/php/php-local.ini || echo 'post_max_size = 100M' >> /config/php/php-local.ini
 
 # check for the mysql endpoint for 30 seconds
 END=$((SECONDS+30))

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -64,6 +64,12 @@ fi
 grep -qx '^upload_max_filesize.*$' /config/php/php-local.ini || echo 'upload_max_filesize = 100M' >> /config/php/php-local.ini
 grep -qx '^post_max_size.*$' /config/php/php-local.ini || echo 'post_max_size = 100M' >> /config/php/php-local.ini
 
+
+## TODO: Remove this following bit by 12/19/2020
+# Remove erronously added configs post-init
+sed -i "s/^upload_max_filesize = 100MB$//g" /config/php/php-local.ini
+sed -i "s/^post_max_size = 100MB$//g" /config/php/php-local.ini
+
 # check for the mysql endpoint for 30 seconds
 END=$((SECONDS+30))
 while [ ${SECONDS} -lt ${END} ] && [ -n "${DB_HOST+x}" ]; do

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -61,8 +61,8 @@ fi
 [ -n "${APP_URL}" ] && sed -r "s,([#\s]*)?APP_URL=.*,APP_URL=${APP_URL},g" -i /config/www/.env
 
 ## Bump php upload max filesize and post max size to 100MB by default
-grep -qxF 'upload_max_filesize' /config/php/php-local.ini || echo 'upload_max_filesize = 100MB' >> /config/php/php-local.ini
-grep -qxF 'post_max_size' /config/php/php-local.ini || echo 'post_max_size = 100MB' >> /config/php/php-local.ini
+grep -qx 'upload_max_filesize' /config/php/php-local.ini || echo 'upload_max_filesize = 100M' >> /config/php/php-local.ini
+grep -qx 'post_max_size' /config/php/php-local.ini || echo 'post_max_size = 100M' >> /config/php/php-local.ini
 
 # check for the mysql endpoint for 30 seconds
 END=$((SECONDS+30))


### PR DESCRIPTION

## Description:
Updates grep to not be both regex & string pattern match to prevent mis-matching of line, also changes "MB" to PHP standard "M"

## Benefits of this PR and context:
If this isn't fixed, all posts & logins seem to fail
It also leads to duplication infinitely every restart


## How Has This Been Tested?
Ran the scripts local in the container to verify functionality in the container.

## Source / References:
https://discordapp.com/channels/354974912613449730/506925392603512839/756980418795798558
