### PR TITLE
Escape special characters in DB_PASS environment variable when substituting with sed

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -55,10 +55,11 @@ fi
 if [ "${DB_USER}" ];
 	then
 	echo "Running config - db_user set"
+	ESCAPED_PASSWORD=$(sed -e 's/[$\/&]/\\&/g' <<< $DB_PASS)
 	sed -i "s/DB_HOST=localhost/DB_HOST=${DB_HOST}/g" /config/www/.env
 	sed -i "s/DB_DATABASE=database_database/DB_DATABASE=${DB_DATABASE}/g" /config/www/.env
 	sed -i "s/DB_USERNAME=database_username/DB_USERNAME=${DB_USER}/g" /config/www/.env
-	sed -i "s/DB_PASSWORD=database_user_password/DB_PASSWORD=${DB_PASS}/g" /config/www/.env
+	sed -i "s/DB_PASSWORD=database_user_password/DB_PASSWORD=${ESCAPED_PASSWORD}/g" /config/www/.env
 fi
 
 # set appurl


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-bookstack/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Escape special characters in DB_PASSWORD environment variable before they're used in a sed substitution.


## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
A `DB_PASS` variable containing any of the following characters will not be output verbatim in a sed replacement string: 

- /
- \
- &
- $

Causing Bookstack initialisations to fail as the DB and Web App are provided with different passwords.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Bash/Zsh:

Old Behaviour:

```bash
matt@matt-pc ~/ $ echo 'DB_PASSWORD=database_user_password' > regex_test.env
matt@matt-pc ~/ $ cat regex_test.env 
DB_PASSWORD=database_user_password
matt@matt-pc ~/ $ sed -i "s/DB_PASSWORD=database_user_password/DB_PASSWORD=${DB_PASS}/g" regex_test.env
matt@matt-pc ~/ $ cat regex_test.env 
DB_PASSWORD=!UX$vzT!2!w6r3sEb2XXFWDB_PASSWORD=database_user_passwordY2byHc
```
New Behaviour:

```bash
matt@laptop ~/ $ DB_PASS='!UX$vzT!2!w6r3sEb2XXFW&Y2byHc'
matt@laptop ~/ $ ESCAPED_PASSWORD=$(sed -e 's/[$\/&]/\\&/g' <<< $DB_PASS)
matt@laptop ~/ $ echo $ESCAPED_PASSWORD                   
!UX\$vzT!2!w6r3sEb2XXFW\&Y2byHc
matt@laptop ~/ $ echo 'DB_PASSWORD=database_user_password' > regex_test.env 
matt@laptop ~/ $ cat regex_test.env                  
DB_PASSWORD=database_user_password
matt@laptop ~/ $ sed -i "s/DB_PASSWORD=database_user_password/DB_PASSWORD=${ESCAPED_PASSWORD}/g" regex_test.env 
matt@laptop ~/ $ cat regex_test.env 
DB_PASSWORD=!UX$vzT!2!w6r3sEb2XXFW&Y2byHc
```


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
Fixes #100 