### PR TITLE
Improve sed and maintain consistency with other database password sed 

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -62,7 +62,7 @@ fi
 if [ "${DB_USER}" ];
 	then
 	echo "Running config - db_user set"
-	ESCAPED_PASSWORD=$(sed -e 's/[$\/&]/\\&/g' <<< $DB_PASS)
+	ESCAPED_PASSWORD=$(sed -E 's/('\'')/\\\1/g' <<< $DB_PASS)
 	sed -i "s/DB_HOST=localhost/DB_HOST=${DB_HOST}/g" /config/www/.env
 	sed -i "s/DB_DATABASE=database_database/DB_DATABASE=${DB_DATABASE}/g" /config/www/.env
 	sed -i "s/DB_USERNAME=database_username/DB_USERNAME=${DB_USER}/g" /config/www/.env


### PR DESCRIPTION

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-bookstack/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
We improved the match in mariadb itself but not other containers, this will align the sed for mariadb and dbpass in bookstack while also improving the actual sed itself.
