### PR TITLE
Remove db_pass escape logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **10.10.22:** - Remove password escape logic which caused problems for a small subset of users.
 * **20.08.22:** - Rebasing to alpine 3.15 with php8. Restructure nginx configs ([see changes announcement](https://info.linuxserver.io/issues/2022-08-20-nginx-base)).
 * **14.03.22:** - Add symlinks for theme support.
 * **11.07.21:** - Rebase to Alpine 3.14.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e APP_URL=` | for specifying the IP:port or URL your application will be accessed on (ie. `http://192.168.1.1:6875` or `https://bookstack.mydomain.com` |
 | `-e DB_HOST=<yourdbhost>` | for specifying the database host |
 | `-e DB_USER=<yourdbuser>` | for specifying the database user |
-| `-e DB_PASS=<yourdbpass>` | for specifying the database password |
+| `-e DB_PASS=<yourdbpass>` | for specifying the database password (non-alphanumeric passwords must be properly escaped.) |
 | `-e DB_DATABASE=bookstackapp` | for specifying the database to be used |
 | `-v /config` | this will store any uploaded data on the docker host |
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -101,6 +101,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "10.10.22:", desc: "Remove password escape logic which caused problems for a small subset of users." }
   - { date: "20.08.22:", desc: "Rebasing to alpine 3.15 with php8. Restructure nginx configs ([see changes announcement](https://info.linuxserver.io/issues/2022-08-20-nginx-base))." }
   - { date: "14.03.22:", desc: "Add symlinks for theme support." }
   - { date: "11.07.21:", desc: "Rebase to Alpine 3.14." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -29,7 +29,7 @@ param_env_vars:
   - { env_var: "DB_HOST", env_value: "<yourdbhost>", desc: "for specifying the database host" }
   - { env_var: "DB_USER", env_value: "<yourdbuser>", desc: "for specifying the database user" }
   - { env_var: "DB_PASS", env_value: "<yourdbpass>", desc: "for specifying the database password" }
-  - { env_var: "DB_DATABASE", env_value: "bookstackapp", desc: "for specifying the database to be used" }
+  - { env_var: "DB_DATABASE", env_value: "bookstackapp", desc: "for specifying the database to be used (non-alphanumeric passwords must be properly escaped.)" }
 
 param_usage_include_ports: true
 param_ports:

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -63,11 +63,10 @@ fi
 if [ "${DB_USER}" ];
 	then
 	echo "Running config - db_user set"
-	ESCAPED_PASSWORD=$(sed -E 's/('\'')/\\\1/g' <<< $DB_PASS)
 	sed -i "s/DB_HOST=localhost/DB_HOST=${DB_HOST}/g" /config/www/.env
 	sed -i "s/DB_DATABASE=database_database/DB_DATABASE=${DB_DATABASE}/g" /config/www/.env
 	sed -i "s/DB_USERNAME=database_username/DB_USERNAME=${DB_USER}/g" /config/www/.env
-	sed -i "s/DB_PASSWORD=database_user_password/DB_PASSWORD=${ESCAPED_PASSWORD}/g" /config/www/.env
+	sed -i "s/DB_PASSWORD=database_user_password/DB_PASSWORD=${DB_PASS}/g" /config/www/.env
 fi
 
 # set appurl


### PR DESCRIPTION
We have had some infrequent complaints about DB_PASS not working at times. Unfortunately, the users who complain never provide any relevant detail that allows us to work to resolve the issue. The logic in this is to attempt to escape special characters in the password before feeding it into the database, the users who have the issue erroneously believe that db_password is the right var because of a lack of understanding, however, this does indicate that bypassing our escape logic is a potential solution. I did some testing with various passwords and had no issues by removing our escape logic at all. 

If this works, we will want to replicate this PR to mariadb and other containers with a similar var and escape logic.