### PR TITLE
Fix Alpine 3.15 not support grep -pP; Improve supporting ipv4|[ipv6]|domain:port; 

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -56,8 +56,9 @@ if ! grep -Fxq "APP_KEY=${key}" /config/www/.env; then
     sed -i "s#^APP_KEY=.*#APP_KEY=${key}#" /config/www/.env
 fi
 
-# if DB_HOST contains a port
-if echo "${DB_HOST}" | grep -qP '^(?:[0-9.]+|(?:\[[0-9a-fA-F:]+\]))(:[0-9]+)$'; then
+# if DB_HOST contains a port and DB_HOST is not a IPv6 without brackets [..]
+# support ipv4:port, [ipv6]:port, and domain:port
+if echo "$DB_HOST" | grep -qE ':[0-9]+$' && ! echo "$DB_HOST" | grep -qE '^(:{0,2}[a-fA-F0-9]{1,4})+$'; then
     DB_HOST_PORT="${DB_HOST}"
 fi
 


### PR DESCRIPTION
Hi Eric Nemchik, I found that `grep -qP` is not support on Alpine 3.15. Also not work with `domain:port` or local `[::1]:port` (sidecar container)

```
grep: unrecognized option: P
BusyBox v1.34.1 (2022-07-19 20:11:24 UTC) multi-call binary.

Usage: grep [-HhnlLoqvsrRiwFE] [-m N] [-A|B|C N] { PATTERN | -e PATTERN... | -f FILE... } [FILE]...

Search for PATTERN in FILEs (or stdin)

        -H      Add 'filename:' prefix
...
```

I would improve the detection by 2 conditions:
- DB_HOST contains a port
- and DB_HOST is not a IPv6 without brackets [..], like 1:2:3::6:7:8

```
if echo "$DB_HOST" | grep -qE ':[0-9]+$' && ! echo "$DB_HOST" | grep -qE '^(:{0,2}[a-fA-F0-9]{1,4})+$'; then
```

This improvement also support
- `[::1]:port`
- `domain:port`
- `ipv4:port`
- `[ipv6]:port`
