### PR TITLE
Fix docker-compose mariadb database path

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ services:
       - MYSQL_USER=bookstack
       - MYSQL_PASSWORD=<yourdbpass>
     volumes:
-      - /path/to/data:/config
+      - /path/to/data:/var/lib/mysql:rw
     restart: unless-stopped
 
 ```


### PR DESCRIPTION
Current docker-compose example will result in data loss on container recreation

## Description:
Changed docker-compose to achieve data persistence on container recreation
<!--- Describe your changes in detail -->

## Benefits of this PR and context:
Prevents accidental data loss
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
Checked for bookstack content persistence after running:
```
docker-compose stop
docker-compose rm -f
docker-compose pull
docker-compose up -d --build --remove-orphans
docker image prune
```
