### PR TITLE
This will fix bug for APP_PROXIES environment + added Bookstack Time Zone environment in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ services:
       - PUID=1000
       - PGID=1000
       - APP_URL=
+      - APP_TIMEZONE=Europe/London
       - DB_HOST=bookstack_db
       - DB_USER=bookstack
       - DB_PASS=<yourdbpass>
@@ -136,6 +137,7 @@ docker run -d \
   -e PUID=1000 \
   -e PGID=1000 \
   -e APP_URL= \
+  -e APP_TIMEZONE=Europe/London \
   -e DB_HOST=<yourdbhost> \
   -e DB_USER=<yourdbuser> \
   -e DB_PASS=<yourdbpass> \
@@ -155,6 +157,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-p 80` | will map the container's port 80 to port 6875 on the host |
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
+| `-e APP_TIMEZONE=Europe/London` | Specify a timezone to use EG Europe/London. |
 | `-e APP_URL=` | for specifying the IP:port or URL your application will be accessed on (ie. `http://192.168.1.1:6875` or `https://bookstack.mydomain.com` |
 | `-e DB_HOST=<yourdbhost>` | for specifying the database host |
 | `-e DB_USER=<yourdbuser>` | for specifying the database user |

--- a/root/defaults/nginx/site-confs/default.conf.sample
+++ b/root/defaults/nginx/site-confs/default.conf.sample
@@ -11,7 +11,12 @@ server {
 
     root /app/www/public;
     index index.html index.htm index.php;
-
+    
+    # display real ip in nginx logs when connected through reverse proxy via docker network or via docker_mods=cloudflared
+    set_real_ip_from  127.0.0.1;
+    set_real_ip_from  172.16.0.0/12;
+    real_ip_header    X-Forwarded-For;
+    
     location / {
         # enable for basic auth
         #auth_basic "Restricted";


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-bookstack/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
This will fix bug for APP_PROXIES environment. USE CASE: fail2ban.
## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
anyone that uses APP_PROXIES and wants to enable logging with LOG_FAILED_LOGIN_MESSAGE="Failed login for %u" can see real IP at /config/log/nginx/error.log

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://www.bookstackapp.com/docs/admin/security/

https://github.com/BookStackApp/BookStack/issues/3619
