### PR TITLE
Added php81-iconv as an installed php extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN \
     php81-curl \
     php81-dom \
     php81-gd \
+    php81-iconv \
     php81-ldap \
     php81-mysqlnd \
     php81-pdo_mysql \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -24,6 +24,7 @@ RUN \
     php81-curl \
     php81-dom \
     php81-gd \
+    php81-iconv \
     php81-ldap \
     php81-mysqlnd \
     php81-pdo_mysql \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -24,6 +24,7 @@ RUN \
     php81-curl \
     php81-dom \
     php81-gd \
+    php81-iconv \
     php81-ldap \
     php81-mysqlnd \
     php81-pdo_mysql \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -104,6 +104,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "01.03.23:", desc: "Add php iconv." }
   - { date: "19.01.23:", desc: "Rebase to alpine 3.17 with php8.1." }
   - { date: "16.01.23:", desc: "Wrap `.env` values in quotes." }
   - { date: "05.01.23:", desc: "Fix db password setting (sed escape `&`)." }


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-bookstack/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

This adds the `iconv` PHP extension to the build scripts since the iconv php extension is a requirement for BookStack that has previously been poly-filled but is now needed as an extension. 

See https://github.com/linuxserver/docker-bookstack/issues/162 for more detail. 

## Benefits of this PR and context:

This adds a required extension that's needed in certain features of BookStack, such as QR code generation for TOTP MFA. 

## How Has This Been Tested?

I build a fresh image for the modified files, then used that in a compose setup to check the image worked, at that the error produced from the lack of the `iconv` extension no longer shows.
I also checked the build log to ensure the `icon` extension is no longer uninstalled in the build process, like it was before.

This was on an x64 Fedora Linux 37 system. 
I did not test the arm image(s) specifically. 

## Source / References:

https://github.com/linuxserver/docker-bookstack/issues/162
