### PR TITLE
Added file/folder path mapping to readme

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -87,9 +87,22 @@ app_setup_block: |
   This application is dependent on a MySQL database be it one you already have or a new one. If you do not already have one, set up our MariaDB container here https://hub.docker.com/r/linuxserver/mariadb/.
 
   
-  If you intend to use this application behind a subfolder reverse proxy, such as our SWAG container or Traefik you will need to make sure that the `APP_URL` environment variable is set to your external domain, or it will not work
+  If you intend to use this application behind a subfolder reverse proxy, such as our SWAG container or Traefik you will need to make sure that the `APP_URL` environment variable is set to your external domain, or it will not work.
 
-  Documentation for BookStack can be found at https://www.bookstackapp.com/docs/
+  Documentation for BookStack can be found at https://www.bookstackapp.com/docs/.
+
+  ### BookStack File & Directory Paths
+  This container ensures certain BookStack application files & folders, such as user file upload folders, are retained within the `/config` folder so that they are persistent & accessible when the `/config` container path is bound as a volume. There may be cases, when following the BookStack documentation, that you'll need to know how these files and folders are used relative to a non-container BookStack installation.
+
+  Below is a mapping of container `/config` paths to those relative within a BookStack install directory:
+
+  - **/config container path** => **BookStack relative path**
+  - `/config/www/.env` => `.env`
+  - `/config/www/laravel.log` => `storage/logs/laravel.log`
+  - `/config/www/files/` => `storage/uploads/files/`
+  - `/config/www/images/` => `storage/uploads/images/`
+  - `/config/www/themes/` => `themes/`
+  - `/config/www/uploads/` => `public/uploads/`
 
   ### Advanced Users (full control over the .env file)
   If you wish to use the extra functionality of BookStack such as email, Memcache, LDAP and so on you will need to make your own .env file with guidance from the BookStack documentation.


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-bookstack/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

This adds details of how BookStack files and folders within the container `/config` volume relate to those within a default BookStack installation.

## Benefits of this PR and context:

Related to #167.

The default file/folder names used within the mounted `/config` folder only match those within a BookStack installation by name, and they can be tricky to understand without understanding how these are linked within the container. Users can often need to know/use these files and directories when following BookStack documentation, for things like migrations from non-docker installs, or when switching between image storage options.

## How Has This Been Tested?

I have read-through my changes a couple of times, and ran them through the jenkins-builder process then checked the `README.md` file output to ensure it was valid.

## Source / References:

- https://github.com/linuxserver/docker-bookstack/issues/167
- https://github.com/BookStackApp/BookStack/issues/4161
