### PR TITLE
Drizuid patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,6 @@ If you wish to use the extra functionality of BookStack such as email, Memcache,
   
 When you create the container, do not set any arguments for any SQL settings. The container will copy an exemplary .env file to /config/www/.env on your host system for you to edit.
 
-#### PDF Rendering
-[wkhtmltopdf](https://wkhtmltopdf.org/) is available to use as an alternative PDF rendering generator as described at https://www.bookstackapp.com/docs/admin/pdf-rendering/.
-
-The path to wkhtmltopdf in this image to include in your .env file is `/usr/bin/wkhtmltopdf`.
-
 ## Usage
 
 Here are some example snippets to help you get started creating a container.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -108,11 +108,6 @@ app_setup_block: |
   If you wish to use the extra functionality of BookStack such as email, Memcache, LDAP and so on you will need to make your own .env file with guidance from the BookStack documentation.
     
   When you create the container, do not set any arguments for any SQL settings. The container will copy an exemplary .env file to /config/www/.env on your host system for you to edit.
-  
-  #### PDF Rendering
-  [wkhtmltopdf](https://wkhtmltopdf.org/) is available to use as an alternative PDF rendering generator as described at https://www.bookstackapp.com/docs/admin/pdf-rendering/.
-  
-  The path to wkhtmltopdf in this image to include in your .env file is `/usr/bin/wkhtmltopdf`.
 
 
 # changelog


### PR DESCRIPTION
alpine dropped support for wkhtmltopdf but we left it in the readme as a method to render pdf. There may be some users working on a PR with weasyprint, but no reply lately from them.  this PR simply removes the notes in the readme for pdf rendering.