### PR TITLE
Update password restriction matching to db image manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e DB_HOST=<yourdbhost>` | for specifying the database host |
 | `-e DB_PORT=<yourdbport>` | for specifying the database port if not default 3306 |
 | `-e DB_USER=<yourdbuser>` | for specifying the database user |
-| `-e DB_PASS=<yourdbpass>` | for specifying the database password (non-alphanumeric passwords must be properly escaped.) |
+| `-e DB_PASS=<yourdbpass>` | for specifying the database password (minimum 4 characters & non-alphanumeric passwords must be properly escaped.) |
 | `-e DB_DATABASE=bookstackapp` | for specifying the database to be used |
 | `-v /config` | this will store any uploaded data on the docker host |
 


### PR DESCRIPTION
per linuxserver/mariadb/, the required DATABASE_PASSWORD must > 4

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [O ] I have read the [contributing](https://github.com/linuxserver/docker-bookstack/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
The user manual on this repo did not sync with it's dependency https://hub.docker.com/r/linuxserver/mariadb/.

Per mariadb image, the required DATABASE_PASSWORD must greater than 4 characters.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

New user who sets password less than 4 char will cause error similar to database connection issue where previous issues are all arguing DB_PASS or DB_PASSWORD which is not the solution here.

In short, it is extremely difficult to troubleshoot this error. Eventually, I decided to RTFM for one layer up which discovered the solution. This update to README should help preventing future user to pull their hair out.

** PR rule says don't PR for README typo. But this is manual content change. :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test: setting longer password worked and short password does not.
Hardware: Raspberry PI 4B.
OS: Raspberry PI OS lite, arm64/v8

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

https://github.com/linuxserver/docker-mariadb#parameters

