### PR TITLE
Update upstream BookStack source as project moved from github to codeberg

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -16,6 +16,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
         env:
           SKIP_EXTERNAL_TRIGGER: ${{ vars.SKIP_EXTERNAL_TRIGGER }}
+          RSS_DELAY_MINUTES: ${{ vars.RSS_DELAY_MINUTES }}
         run: |
           printf "# External trigger for docker-bookstack\n\n" >> $GITHUB_STEP_SUMMARY
           if grep -q "^bookstack_master_" <<< "${SKIP_EXTERNAL_TRIGGER}"; then
@@ -29,8 +30,32 @@ jobs:
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> External trigger running off of master branch. To disable this trigger, add \`bookstack_master\` into the Github organizational variable \`SKIP_EXTERNAL_TRIGGER\`." >> $GITHUB_STEP_SUMMARY
           printf "\n## Retrieving external version\n\n" >> $GITHUB_STEP_SUMMARY
-          EXT_RELEASE=$(curl -sL "https://codeberg.org/bookstack/bookstack/releases.rss" \
+          RSS_FEED=$(curl -sL "https://codeberg.org/bookstack/bookstack/releases.rss")
+          EXT_RELEASE=$(printf '%s' "${RSS_FEED}" \
             | awk '/<entry>|<item>/ {found=1} found && /<link>https:\/\/codeberg.org\/bookstack\/bookstack\/releases\/tag\// { gsub(/.*<link>https:\/\/codeberg.org\/bookstack\/bookstack\/releases\/tag\//,"", $0); gsub(/<\/link>.*/,"", $0); print $0; exit }')
+          RSS_PUBDATE=$(printf '%s' "${RSS_FEED}" \
+            | awk '/<item>|<entry>/ {found=1} found && /<pubDate>/ { gsub(/.*<pubDate>/, "", $0); gsub(/<\/pubDate>.*/, "", $0); print; exit }')
+          if [ -z "${RSS_PUBDATE}" ]; then
+            RSS_PUBDATE=$(printf '%s' "${RSS_FEED}" \
+              | awk '/<pubDate>/ { gsub(/.*<pubDate>/, "", $0); gsub(/<\/pubDate>.*/, "", $0); print; exit }')
+          fi
+          DELAY_MIN=${RSS_DELAY_MINUTES:-6}
+          if [ -n "${RSS_PUBDATE}" ]; then
+            RSS_EPOCH=$(date -d "${RSS_PUBDATE}" +%s 2>/dev/null || true)
+            if [ -n "${RSS_EPOCH}" ]; then
+              NOW_EPOCH=$(date -u +%s)
+              AGE_SEC=$((NOW_EPOCH - RSS_EPOCH))
+              DELAY_SEC=$((DELAY_MIN * 60))
+              if [ "${AGE_SEC}" -lt "${DELAY_SEC}" ]; then
+                echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
+                echo "> Codeberg RSS was updated ${AGE_SEC} seconds ago; skipping this run as newest entry has to be older than ${DELAY_MIN} minutes. (Based on RSS pubDate)" >> $GITHUB_STEP_SUMMARY
+                exit 0
+              fi
+            fi
+          else
+            echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
+            echo "> Could not parse RSS pubDate; proceeding without additional delay." >> $GITHUB_STEP_SUMMARY
+          fi
           echo "Type is \`codeberg_rss\`" >> $GITHUB_STEP_SUMMARY
           if grep -q "^bookstack_master_${EXT_RELEASE}" <<< "${SKIP_EXTERNAL_TRIGGER}"; then
             echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -29,8 +29,9 @@ jobs:
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> External trigger running off of master branch. To disable this trigger, add \`bookstack_master\` into the Github organizational variable \`SKIP_EXTERNAL_TRIGGER\`." >> $GITHUB_STEP_SUMMARY
           printf "\n## Retrieving external version\n\n" >> $GITHUB_STEP_SUMMARY
-          EXT_RELEASE=$(curl -u "${{ secrets.CR_USER }}:${{ secrets.CR_PAT }}" -sX GET "https://api.github.com/repos/bookstackapp/bookstack/releases/latest" | jq -r '. | .tag_name')
-          echo "Type is \`github_stable\`" >> $GITHUB_STEP_SUMMARY
+          EXT_RELEASE=$(curl -sL "https://codeberg.org/bookstack/bookstack/releases.rss" \
+            | awk '/<entry>|<item>/ {found=1} found && /<link>https:\/\/codeberg.org\/bookstack\/bookstack\/releases\/tag\// { gsub(/.*<link>https:\/\/codeberg.org\/bookstack\/bookstack\/releases\/tag\//,"", $0); gsub(/<\/link>.*/,"", $0); print $0; exit }')
+          echo "Type is \`codeberg_rss\`" >> $GITHUB_STEP_SUMMARY
           if grep -q "^bookstack_master_${EXT_RELEASE}" <<< "${SKIP_EXTERNAL_TRIGGER}"; then
             echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
             echo "> Github organizational variable \`SKIP_EXTERNAL_TRIGGER\` matches current external release; skipping trigger." >> $GITHUB_STEP_SUMMARY
@@ -39,7 +40,7 @@ jobs:
           if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
             echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
             echo "> Can't retrieve external version, exiting" >> $GITHUB_STEP_SUMMARY
-            FAILURE_REASON="Can't retrieve external version for bookstack branch master"
+            FAILURE_REASON="Can't retrieve external version for bookstack using codeberg rss feed"
             GHA_TRIGGER_URL="https://github.com/linuxserver/docker-bookstack/actions/runs/${{ github.run_id }}"
             curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 16711680,
               "description": "**Trigger Failed** \n**Reason:** '"${FAILURE_REASON}"' \n**Trigger URL:** '"${GHA_TRIGGER_URL}"' \n"}],
@@ -139,7 +140,7 @@ jobs:
                 --data-urlencode "description=GHA external trigger https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
                 --data-urlencode "Submit=Submit"
               echo "**** Notifying Discord ****"
-              TRIGGER_REASON="A version change was detected for bookstack tag latest. Old version:${IMAGE_VERSION} New version:${EXT_RELEASE_SANITIZED}"
+              TRIGGER_REASON="A version change was detected for bookstack using codeberg rss feed. Old version:${IMAGE_VERSION} New version:${EXT_RELEASE_SANITIZED}"
               curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
                 "description": "**Build Triggered** \n**Reason:** '"${TRIGGER_REASON}"' \n**Build URL:** '"${buildurl}display/redirect"' \n"}],
                 "username": "Github Actions"}' ${{ secrets.DISCORD_WEBHOOK }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,13 +34,13 @@ RUN \
   echo "**** fetch bookstack ****" && \
   mkdir -p\
     /app/www && \
-  if [ -z ${BOOKSTACK_RELEASE+x} ]; then \
-    BOOKSTACK_RELEASE=$(curl -sX GET "https://api.github.com/repos/bookstackapp/bookstack/releases/latest" \
-    | awk '/tag_name/{print $4;exit}' FS='[""]'); \
+  if [ -z "${BOOKSTACK_RELEASE+x}" ]; then \
+    BOOKSTACK_RELEASE=$(curl -sL "https://codeberg.org/bookstack/bookstack/releases.rss" \
+      | awk '/<entry>|<item>/ {found=1} found && /<link>https:\/\/codeberg.org\/bookstack\/bookstack\/releases\/tag\// { gsub(/.*<link>https:\/\/codeberg.org\/bookstack\/bookstack\/releases\/tag\//,"", $0); gsub(/<\/link>.*/,"", $0); print $0; exit }'); \
   fi && \
   curl -o \
     /tmp/bookstack.tar.gz -L \
-    "https://github.com/BookStackApp/BookStack/archive/${BOOKSTACK_RELEASE}.tar.gz" && \
+    "https://source.bookstackapp.com/bookstack/snapshot/bookstack-${BOOKSTACK_RELEASE}.tar.gz" && \
   tar xf \
     /tmp/bookstack.tar.gz -C \
     /app/www/ --strip-components=1 && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -34,13 +34,13 @@ RUN \
   echo "**** fetch bookstack ****" && \
   mkdir -p\
     /app/www && \
-  if [ -z ${BOOKSTACK_RELEASE+x} ]; then \
-    BOOKSTACK_RELEASE=$(curl -sX GET "https://api.github.com/repos/bookstackapp/bookstack/releases/latest" \
-    | awk '/tag_name/{print $4;exit}' FS='[""]'); \
+  if [ -z "${BOOKSTACK_RELEASE+x}" ]; then \
+    BOOKSTACK_RELEASE=$(curl -sL "https://codeberg.org/bookstack/bookstack/releases.rss" \
+      | awk '/<entry>|<item>/ {found=1} found && /<link>https:\/\/codeberg.org\/bookstack\/bookstack\/releases\/tag\// { gsub(/.*<link>https:\/\/codeberg.org\/bookstack\/bookstack\/releases\/tag\//,"", $0); gsub(/<\/link>.*/,"", $0); print $0; exit }'); \
   fi && \
   curl -o \
     /tmp/bookstack.tar.gz -L \
-    "https://github.com/BookStackApp/BookStack/archive/${BOOKSTACK_RELEASE}.tar.gz" && \
+    "https://source.bookstackapp.com/bookstack/snapshot/bookstack-${BOOKSTACK_RELEASE}.tar.gz" && \
   tar xf \
     /tmp/bookstack.tar.gz -C \
     /app/www/ --strip-components=1 && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,9 +19,6 @@ pipeline {
     DOCKERHUB_TOKEN=credentials('docker-hub-ci-pat')
     QUAYIO_API_TOKEN=credentials('quayio-repo-api-token')
     GIT_SIGNING_KEY=credentials('484fbca6-9a4f-455e-b9e3-97ac98785f5f')
-    EXT_GIT_BRANCH = 'master'
-    EXT_USER = 'bookstackapp'
-    EXT_REPO = 'bookstack'
     BUILD_VERSION_ARG = 'BOOKSTACK_RELEASE'
     LS_USER = 'linuxserver'
     LS_REPO = 'docker-bookstack'
@@ -146,25 +143,26 @@ pipeline {
     /* ########################
        External Release Tagging
        ######################## */
-    // If this is a stable github release use the latest endpoint from github to determine the ext tag
-    stage("Set ENV github_stable"){
+    // Determine the external BookStack release tag from Codeberg RSS
+    stage("Set ENV external_release"){
      steps{
        script{
          env.EXT_RELEASE = sh(
-           script: '''curl -H "Authorization: token ${GITHUB_TOKEN}" -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest | jq -r '. | .tag_name' ''',
+           script: '''curl -sL https://codeberg.org/bookstack/bookstack/releases.rss \
+             | awk '/<entry>|<item>/ {found=1} found && /<link>https:\/\/codeberg.org\/bookstack\/bookstack\/releases\/tag\// { gsub(/.*<link>https:\/\/codeberg.org\/bookstack\/bookstack\/releases\/tag\//,"", $0); gsub(/<\/link>.*/,"", $0); print $0; exit }' ''',
            returnStdout: true).trim()
        }
      }
     }
-    // If this is a stable or devel github release generate the link for the build message
-    stage("Set ENV github_link"){
+    // Generate the release link for the build message from the BookStack snapshot source URL
+    stage("Set ENV release_link"){
      steps{
        script{
-         env.RELEASE_LINK = 'https://github.com/' + env.EXT_USER + '/' + env.EXT_REPO + '/releases/tag/' + env.EXT_RELEASE
+         env.RELEASE_LINK = 'https://source.bookstackapp.com/bookstack/'
        }
      }
     }
-    // Sanitize the release tag and strip illegal docker or github characters
+    // Sanitize the release tag and strip illegal characters
     stage("Sanitize tag"){
       steps{
         script{
@@ -603,7 +601,7 @@ pipeline {
           --label \"org.opencontainers.image.licenses=GPL-3.0-only\" \
           --label \"org.opencontainers.image.ref.name=${COMMIT_SHA}\" \
           --label \"org.opencontainers.image.title=Bookstack\" \
-          --label \"org.opencontainers.image.description=[Bookstack](https://github.com/BookStackApp/BookStack) is a free and open source Wiki designed for creating beautiful documentation. Featuring a simple, but powerful WYSIWYG editor it allows for teams to create detailed and useful documentation with ease.    Powered by SQL and including a Markdown editor for those who prefer it, BookStack is geared towards making documentation more of a pleasure than a chore.    For more information on BookStack visit their website and check it out: https://www.bookstackapp.com  \" \
+          --label \"org.opencontainers.image.description=[Bookstack](https://codeberg.org/bookstack/bookstack) is a free and open source Wiki designed for creating beautiful documentation. Featuring a simple, but powerful WYSIWYG editor it allows for teams to create detailed and useful documentation with ease.    Powered by SQL and including a Markdown editor for those who prefer it, BookStack is geared towards making documentation more of a pleasure than a chore.    For more information on BookStack visit their website and check it out: https://www.bookstackapp.com  \" \
           --no-cache --pull -t ${IMAGE}:${META_TAG} --platform=linux/amd64 \
           --provenance=true --sbom=true --builder=container --load \
           --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${VERSION_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
@@ -672,7 +670,7 @@ pipeline {
               --label \"org.opencontainers.image.licenses=GPL-3.0-only\" \
               --label \"org.opencontainers.image.ref.name=${COMMIT_SHA}\" \
               --label \"org.opencontainers.image.title=Bookstack\" \
-              --label \"org.opencontainers.image.description=[Bookstack](https://github.com/BookStackApp/BookStack) is a free and open source Wiki designed for creating beautiful documentation. Featuring a simple, but powerful WYSIWYG editor it allows for teams to create detailed and useful documentation with ease.    Powered by SQL and including a Markdown editor for those who prefer it, BookStack is geared towards making documentation more of a pleasure than a chore.    For more information on BookStack visit their website and check it out: https://www.bookstackapp.com  \" \
+              --label \"org.opencontainers.image.description=[Bookstack](https://codeberg.org/bookstack/bookstack) is a free and open source Wiki designed for creating beautiful documentation. Featuring a simple, but powerful WYSIWYG editor it allows for teams to create detailed and useful documentation with ease.    Powered by SQL and including a Markdown editor for those who prefer it, BookStack is geared towards making documentation more of a pleasure than a chore.    For more information on BookStack visit their website and check it out: https://www.bookstackapp.com  \" \
               --no-cache --pull -t ${IMAGE}:amd64-${META_TAG} --platform=linux/amd64 \
               --provenance=true --sbom=true --builder=container --load \
               --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${VERSION_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
@@ -734,7 +732,7 @@ pipeline {
               --label \"org.opencontainers.image.licenses=GPL-3.0-only\" \
               --label \"org.opencontainers.image.ref.name=${COMMIT_SHA}\" \
               --label \"org.opencontainers.image.title=Bookstack\" \
-              --label \"org.opencontainers.image.description=[Bookstack](https://github.com/BookStackApp/BookStack) is a free and open source Wiki designed for creating beautiful documentation. Featuring a simple, but powerful WYSIWYG editor it allows for teams to create detailed and useful documentation with ease.    Powered by SQL and including a Markdown editor for those who prefer it, BookStack is geared towards making documentation more of a pleasure than a chore.    For more information on BookStack visit their website and check it out: https://www.bookstackapp.com  \" \
+              --label \"org.opencontainers.image.description=[Bookstack](https://codeberg.org/bookstack/bookstack) is a free and open source Wiki designed for creating beautiful documentation. Featuring a simple, but powerful WYSIWYG editor it allows for teams to create detailed and useful documentation with ease.    Powered by SQL and including a Markdown editor for those who prefer it, BookStack is geared towards making documentation more of a pleasure than a chore.    For more information on BookStack visit their website and check it out: https://www.bookstackapp.com  \" \
               --no-cache --pull -f Dockerfile.aarch64 -t ${IMAGE}:arm64v8-${META_TAG} --platform=linux/arm64 \
               --provenance=true --sbom=true --builder=container --load \
               --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${VERSION_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
@@ -1032,7 +1030,8 @@ pipeline {
                   "type": "commit",\
                   "tagger": {"name": "LinuxServer-CI","email": "ci@linuxserver.io","date": "'${GITHUB_DATE}'"}}'
               echo "Pushing New release for Tag"
-              curl -H "Authorization: token ${GITHUB_TOKEN}" -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest | jq -r '. |.body' > releasebody.json
+              curl -fsSL https://codeberg.org/bookstack/bookstack/releases.rss \
+                | awk '/<item>/ {found=1} found && /<link>https:\/\/codeberg.org\/bookstack\/bookstack\/releases\/tag\// { gsub(/.*<link>/,"", $0); gsub(/<\/link>.*/,"", $0); print; exit }' > releasebody.json || echo "" > releasebody.json
               jq -n \
                 --arg tag_name "$META_TAG" \
                 --arg target_commitish "master" \

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,7 +2,7 @@
 
 # jenkins variables
 project_name: docker-bookstack
-external_type: github_stable
+external_type: codeberg_rss
 release_type: stable
 release_tag: latest
 ls_branch: master

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -136,7 +136,7 @@ init_diagram: |
   "bookstack:latest" <- Base Images
 # changelog
 changelogs:
-  - {date: "29.04.26:", desc: "Update upstream BookStack source as project moved from github to codeberg."}
+  - {date: "30.04.26:", desc: "Update upstream BookStack source as project moved from github to codeberg."}
   - {date: "28.12.25:", desc: "Rebase to Alpine 3.23."}
   - {date: "05.07.25:", desc: "Rebase to Alpine 3.22."}
   - {date: "04.01.25:", desc: "Add php-opcache."}

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -2,7 +2,7 @@
 
 # project information
 project_name: bookstack
-project_url: "https://github.com/BookStackApp/BookStack"
+project_url: "https://codeberg.org/bookstack/bookstack"
 project_logo: "https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/bookstack-logo.png"
 project_lsio_github_repo_url: "https://github.com/linuxserver/docker-{{ project_name }}"
 project_categories: "Content Management"
@@ -136,6 +136,7 @@ init_diagram: |
   "bookstack:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "29.04.26:", desc: "Update upstream BookStack source as project moved from github to codeberg."}
   - {date: "28.12.25:", desc: "Rebase to Alpine 3.23."}
   - {date: "05.07.25:", desc: "Rebase to Alpine 3.22."}
   - {date: "04.01.25:", desc: "Add php-opcache."}


### PR DESCRIPTION
 - [x] I have read the [contributing](https://github.com/linuxserver/docker-bookstack/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
The Bookstack project moved away from GitHub.
This PR updates the BookStack build pipeline and documentation, so the upstream project source uses Codeberg instead of GitHub. The change covers release discovery, download URLs, documentation references, and the repository changelog. I spoke to @ssddanbrown about some details, and he said there could be a 5-minute delay before the tarball is updated. Therefore, I added a configurable delay, currently set to 6 minutes.

## Benefits of this PR and context:
- Removes dependency on the GitHub BookStack release API.
- Aligns release detection with the actual upstream project hosting location.
- Uses Codeberg RSS for automated version parsing in build flows.
- Updates documentation links and changelog entries to the new upstream source.

## How Has This Been Tested?

- Local build of `Dockerfile` with explicit `BOOKSTACK_RELEASE`
- Local build of `Dockerfile` without `BOOKSTACK_RELEASE` to verify automatic RSS-based version detection
- Local and GitHub Workflow tests to verify trigger (in test branch, not included in this PR)

## Source / References:

- https://www.bookstackapp.com/blog/project-migrated-to-codeberg/
- https://codeberg.org/bookstack/bookstack