### PR TITLE
Run queue worker as abc user

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -136,6 +136,7 @@ init_diagram: |
   "bookstack:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "05.08.26:", desc: "Run the async queue worker as the PUID/PGID-managed abc user."}
   - {date: "05.07.26:", desc: "Rebase to Alpine 3.24."}
   - {date: "29.04.26:", desc: "Switch to pulling releases from [Codeberg](https://codeberg.org/bookstack/bookstack)."}
   - {date: "28.12.25:", desc: "Rebase to Alpine 3.23."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-queue-worker/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-queue-worker/run
@@ -3,4 +3,4 @@
 
 echo "*** Starting Async Action Queue ***"
 
-exec /usr/bin/php /app/www/artisan queue:work --sleep=3 --tries=1 --max-time=3600
+exec /usr/bin/s6-setuidgid abc /usr/bin/php /app/www/artisan queue:work --sleep=3 --tries=1 --max-time=3600


### PR DESCRIPTION
- [x] I have read the [contributing](https://github.com/linuxserver/docker-bookstack/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

## Description:

Run the BookStack async queue worker as the `abc` user using `s6-setuidgid`.

A corresponding changelog entry has also been added to `readme-vars.yml`.

## Benefits of this PR and context:

The queue worker currently inherits root privileges from s6, while PHP-FPM runs as the `abc` user.

If the queue worker is the first process to write to `/config/log/bookstack/laravel.log`, such as during a transient Redis failure, the file is created as `root:root` with mode `0644`. PHP-FPM cannot subsequently append to it, causing Laravel logging to throw an `UnexpectedValueException` and web requests to return HTTP 500 errors.

Running the queue worker as `abc`:

- Prevents root-owned Laravel log files.
- Ensures PHP-FPM and the queue worker can safely share application files.
- Consistently applies the configured `PUID` and `PGID`.
- Avoids requiring startup-time ownership repairs as a workaround.

## How Has This Been Tested?

- Successfully built the complete image using `docker build --no-cache --pull`.
- Started an isolated container from the resulting image with `PUID=1000`, `PGID=1000`, and `QUEUE_CONNECTION=redis`.
- Confirmed the async queue worker ran as UID/GID `1000:1000`.
- Triggered the failure path using an unavailable Redis endpoint.
- Confirmed the queue worker created `/config/log/bookstack/laravel.log` as `1000:1000` with mode `0644`.
- Confirmed the PHP-FPM UID could write to the resulting log file.
- Confirmed PHP-FPM workers also ran as UID/GID `1000:1000`.
- Ran `bash -n` and `git diff --check` successfully.

## Source / References:

- Current queue-worker service: https://github.com/linuxserver/docker-bookstack/blob/master/root/etc/s6-overlay/s6-rc.d/svc-queue-worker/run
- LinuxServer contribution guidelines: https://github.com/linuxserver/docker-bookstack/blob/master/.github/CONTRIBUTING.md

## AI assistance disclosure:

The issue investigation and preparation of this change were assisted by OpenAI Codex. The resulting diagnosis, code change, and validation results were reviewed by the contributor.